### PR TITLE
[circle] Explicitly use go-build:1.20 instead of latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   go-build:
     docker:
-      - image: us-docker.pkg.dev/pantheon-artifacts/internal/go-build:latest
+      - image: us-docker.pkg.dev/pantheon-artifacts/internal/go-build:1.20
         auth:
           username: _json_key
           password: $CIRCLE_CI_COMMON_KEY


### PR DESCRIPTION
Deploy step for #9 failed on go mod tidy