### PR TITLE
[CMSP-348] Support "convert_to_subdirectory" in sites.yml

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,6 +37,7 @@ A `sites.yml` file is valid if:
 
 Use wget to download, gzipped pre-compiled binaries:
 For instance, VERSION=v0.0.11 and BINARY=sites-yml-validator_linux_amd64
+Refer to the [Releases](https://github.com/pantheon-systems/sites-yml-validator/releases) page for `VERSION` and `BINARY` parameters
 
 ### Compressed via tar.gz
 ```bash
@@ -51,11 +52,23 @@ wget https://github.com/pantheon-systems/sites-yml-validator/releases/download/$
     chmod +x /usr/bin/sites-yml-validator
 ```
 
-### Latest version
+### Latest version Linux
 
 ```bash
 wget https://github.com/pantheon-systems/sites-yml-validator/releases/latest/download/sites-yml-validator_linux_amd64 -O /usr/bin/sites-yml-validator &&\
     chmod +x /usr/bin/sites-yml-validator
+```
+
+### Latest version Intel processor Mac
+
+```bash
+curl -LO https://github.com/pantheon-systems/sites-yml-validator/releases/latest/download/sites-yml-validator_Darwin_x86_64.tar.gz && tar -xf sites-yml-validator_Darwin_x86_64.tar.gz && sudo mv sites-yml-validator /usr/local/bin/sites-yml-validator && sudo chmod +x /usr/local/bin/sites-yml-validator
+```
+
+### Latest version Apple Silicon processor Mac
+
+```bash
+curl -LO https://github.com/pantheon-systems/sites-yml-validator/releases/latest/download/sites-yml-validator_Darwin_arm64.tar.gz && tar -xf sites-yml-validator_Darwin_arm64.tar.gz && sudo mv sites-yml-validator /usr/local/bin/sites-yml-validator && sudo chmod +x /usr/local/bin/sites-yml-validator
 ```
 
 ## Testing

--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,7 @@ domain_maps:
 ```
 A `sites.yml` file is valid if:
 - the `api_version` is `1`
+- `convert_to_subdirectory` is a boolean `true` or `false`, or the integers `1` or `0`.
 - the key for each item in `domain_maps` is a valid Pantheon environment name (`dev`, `test`, `multidev`, etc.)
 - For each site listed for an environment:
    - the key is an integer

--- a/fixtures/sites/invalid_convert_string.yml
+++ b/fixtures/sites/invalid_convert_string.yml
@@ -1,0 +1,3 @@
+---
+api_version: 1 # Currently only one api version.
+convert_to_subdirectory: "hello"

--- a/fixtures/sites/valid.yml
+++ b/fixtures/sites/valid.yml
@@ -1,6 +1,9 @@
 ---
 api_version: 1 # Currently only one api version.
-
+# convert_to_subdirectory is set if a live site uses subdomains, but all
+# other environments use subdirectory WPMS. Conversion only runs when run
+# FROM the live environment.
+convert_to_subdirectory: false
 # "domain_maps" is a collection of site URLs for each environment used to
 # facilitate search-replace of a WordPress Multisite (WPMS) across pantheon
 # environments. Each key of "domain_maps" must be a valid environment name.

--- a/fixtures/sites/valid_convert.yml
+++ b/fixtures/sites/valid_convert.yml
@@ -1,0 +1,3 @@
+---
+api_version: 1 # Currently only one api version.
+convert_to_subdirectory: true

--- a/fixtures/sites/valid_convert_int.yml
+++ b/fixtures/sites/valid_convert_int.yml
@@ -1,0 +1,3 @@
+---
+api_version: 1 # Currently only one api version.
+convert_to_subdirectory: 1

--- a/pkg/model/sites.go
+++ b/pkg/model/sites.go
@@ -1,9 +1,16 @@
 package model
 
+import (
+	"fmt"
+)
+
+type ConvertBool bool
+
 // SitesYml is used to map domains across environments for search and replace with WPMS sites.
 type SitesYml struct {
-	APIVersion int        `yaml:"api_version"`
-	DomainMaps DomainMaps `yaml:"domain_maps"`
+	APIVersion            int         `yaml:"api_version"`
+	ConvertToSubdirectory ConvertBool `yaml:"convert_to_subdirectory"`
+	DomainMaps            DomainMaps  `yaml:"domain_maps"`
 }
 
 // DomainMaps is a collection of site ID/site domains keyed by environment name.
@@ -11,3 +18,29 @@ type DomainMaps map[string]DomainMapByEnvironment
 
 // DomainMapByEnvironment is a collection of site domains keyed by site ID.
 type DomainMapByEnvironment map[int]string
+
+// A custom Unmarshal method for ConvertBool, accepting true, false, 1, or 0
+// for convert_to_subdirectory.
+func (convert *ConvertBool) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var val interface{}
+	if err := unmarshal(&val); err != nil {
+		return err
+	}
+
+	switch v := val.(type) {
+	case bool:
+		*convert = ConvertBool(v)
+	case int:
+		if v != 1 && v != 0 {
+			return fmt.Errorf(
+				"unexpected int %v for convert_to_subdirectory. Value must be true, false, 1, or 0.",
+				v,
+			)
+		}
+		*convert = v != 0
+	default:
+		return fmt.Errorf("unexpected type %T for convert_to_subdirectory", v)
+	}
+
+	return nil
+}

--- a/pkg/model/sites_test.go
+++ b/pkg/model/sites_test.go
@@ -1,0 +1,95 @@
+package model
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnMarshalConvertBool(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		yaml        string
+		expected    ConvertBool
+		expectedErr error
+	}{
+		{
+			name: "missing",
+			yaml: `
+			---
+			api_version: 1`,
+			expectedErr: nil,
+			expected:    false,
+		},
+		{
+			name: "bool true",
+			yaml: `
+			---
+			convert_to_subdirectory: true`,
+			expectedErr: nil,
+			expected:    true,
+		},
+		{
+			name: "bool false",
+			yaml: `
+			---
+			convert_to_subdirectory: false`,
+			expectedErr: nil,
+			expected:    false,
+		},
+		{
+			name: "int true",
+			yaml: `
+			---
+			convert_to_subdirectory: 1`,
+			expectedErr: nil,
+			expected:    true,
+		},
+		{
+			name: "int false",
+			yaml: `
+			---
+			convert_to_subdirectory: 0`,
+			expectedErr: nil,
+			expected:    false,
+		},
+		{
+			name: "int invalid",
+			yaml: `
+			---
+			convert_to_subdirectory: 2`,
+			expectedErr: errors.New(
+				"unexpected int 2 for convert_to_subdirectory. Value must be true, false, 1, or 0.",
+			),
+		},
+		{
+			name: "string invalid",
+			yaml: `
+			---
+			convert_to_subdirectory: "foo"`,
+			expectedErr: errors.New("unexpected type string for convert_to_subdirectory"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			y := []byte(
+				// Yaml doesn't like tabs, but lets us make our test cases prettier
+				strings.ReplaceAll(tc.yaml, "\t", ""),
+			)
+
+			var s SitesYml
+			err := yaml.Unmarshal(y, &s)
+
+			if tc.expectedErr != nil {
+				assert.EqualError(t, err, tc.expectedErr.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, s.ConvertToSubdirectory)
+
+		})
+	}
+}

--- a/pkg/validator/sites_test.go
+++ b/pkg/validator/sites_test.go
@@ -190,7 +190,7 @@ func TestValidateFromYaml(t *testing.T) {
 			expected: ErrInvalidAPIVersion,
 		},
 		{
-			name: "invalid api_version ",
+			name: "invalid yaml",
 			yaml: `this is not good yaml`,
 			expected: &yaml.TypeError{
 				Errors: []string{
@@ -232,6 +232,9 @@ func TestValidateSitesFromFilePath(t *testing.T) {
 				"error reading YAML file: open ../../fixtures/sites/this_file_does_not_exist.yml: no such file or directory",
 			),
 		},
+		{"valid_convert", nil},
+		{"valid_convert_int", nil},
+		{"invalid_convert_string", errors.New("unexpected type string for convert_to_subdirectory")},
 	} {
 		t.Run(tc.fixtureName, func(t *testing.T) {
 			v, err := ValidatorFactory("sites")


### PR DESCRIPTION
Some customers have subdomains setup on their live sites, but convert to subdirectory for all other instances (c/f https://github.com/ryanshoover/quicksilver-wpmu-db-clone).

This validates a convert_to_subdirectory flag in sites.yml.

Also pulled in @carl-alberto's README from #24 to avoid cutting a new release solely because of docs